### PR TITLE
Arguments for write_text_features

### DIFF
--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -47,7 +47,7 @@ def write_features(dataset_dir: str, save_dir: str, annotation_name: str, valida
     """
     os.makedirs(save_dir, exist_ok=True)
 
-    print('Initializing the dataset provider... ', end='')
+    print('Initializing the dataset provider... ', end='', flush=True)
 
     provider = data_provider.TextDataProvider(dataset_dir=dataset_dir, annotation_name=annotation_name,
                                               validation_set=validation_split > 0, validation_split=validation_split,

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -12,48 +12,49 @@ import os
 import os.path as ops
 import argparse
 import numpy as np
-import cv2
-try:
-    from cv2 import cv2
-except ImportError:
-    pass
 
 from data_provider import data_provider
 from local_utils import data_utils
 
 
-def init_args():
-    """
+def init_args() -> argparse.Namespace:
+    """ Parses command line arguments
 
-    :return:
+    :return: Parsed arguments
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset_dir', type=str, help='Where you store the dataset')
-    parser.add_argument('--save_dir', type=str, help='Where you store tfrecords')
+    parser.add_argument('-d', '--dataset_dir', type=str, help='Path to "Train" and "Test" folders with data')
+    parser.add_argument('-s', '--save_dir', type=str, help='Where to store the generated tfrecords')
+    parser.add_argument('-a', '--annotation_file', type=str, default='sample.txt',
+                        help='Name of annotations file (in dataset_dir/Train and dataset_dir/Test)')
+    parser.add_argument('-v', '--validation_split', type=float, default=0.15,
+                        help='Fraction of training data to use for validation')
 
     return parser.parse_args()
 
 
-def write_features(dataset_dir, save_dir):
-    """
+def write_features(dataset_dir: str, save_dir: str, annotation_name: str, validation_split: float):
+    """ Processes training and test data creating Tensorflow records.
 
-    :param dataset_dir:
-    :param save_dir:
-    :return:
+    :param dataset_dir: root to Train and Test datasets
+    :param save_dir: Where to store the tf records
+    :param annotation_name: Name of annotations file in each dataset dir
+    :param validation_split: Fraction of training data to use for validation
     """
     if not ops.exists(save_dir):
         os.makedirs(save_dir)
 
-    print('Initialize the dataset provider ......')
-    provider = data_provider.TextDataProvider(dataset_dir=dataset_dir, annotation_name='sample.txt',
-                                              validation_set=True, validation_split=0.15, shuffle='every_epoch',
-                                              normalization=None)
-    print('Dataset provider intialize complete')
+    print('Initializing the dataset provider... ', end='')
+
+    provider = data_provider.TextDataProvider(dataset_dir=dataset_dir, annotation_name=annotation_name,
+                                              validation_set=True, validation_split=validation_split,
+                                              shuffle='every_epoch', normalization=None)
+    print('done.')
 
     feature_io = data_utils.TextFeatureIO()
 
     # write train tfrecords
-    print('Start writing training tf records')
+    print('Writing tf records for training...')
 
     train_images = provider.train.images
     train_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in train_images]
@@ -65,7 +66,7 @@ def write_features(dataset_dir, save_dir):
                                      imagenames=train_imagenames)
 
     # write test tfrecords
-    print('Start writing testing tf records')
+    print('Writing tf records for testing...')
 
     test_images = provider.test.images
     test_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in test_images]
@@ -77,7 +78,7 @@ def write_features(dataset_dir, save_dir):
                                      imagenames=test_imagenames)
 
     # write val tfrecords
-    print('Start writing validation tf records')
+    print('Writing tf records for validation...')
 
     val_images = provider.validation.images
     val_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in val_images]
@@ -88,8 +89,6 @@ def write_features(dataset_dir, save_dir):
     feature_io.writer.write_features(tfrecords_path=val_tfrecord_path, labels=val_labels, images=val_images,
                                      imagenames=val_imagenames)
 
-    return
-
 
 if __name__ == '__main__':
     # init args
@@ -98,4 +97,5 @@ if __name__ == '__main__':
         raise ValueError('Dataset {:s} doesn\'t exist'.format(args.dataset_dir))
 
     # write tf records
-    write_features(dataset_dir=args.dataset_dir, save_dir=args.save_dir)
+    write_features(dataset_dir=args.dataset_dir, save_dir=args.save_dir, annotation_name=args.annotation_file,
+                   validation_split=args.validation_split)

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -23,8 +23,10 @@ def init_args() -> argparse.Namespace:
     :return: Parsed arguments
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--dataset_dir', type=str, help='Path to "Train" and "Test" folders with data')
-    parser.add_argument('-s', '--save_dir', type=str, help='Where to store the generated tfrecords')
+    parser.add_argument('-d', '--dataset_dir', type=str, required=True,
+                        help='Path to "Train" and "Test" folders with data')
+    parser.add_argument('-s', '--save_dir', type=str, required=True,
+                        help='Where to store the generated tfrecords')
     parser.add_argument('-a', '--annotation_file', type=str, default='sample.txt',
                         help='Name of annotations file (in dataset_dir/Train and dataset_dir/Test)')
     parser.add_argument('-v', '--validation_split', type=float, default=0.15,

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -51,7 +51,7 @@ def write_features(dataset_dir: str, save_dir: str, annotation_name: str, valida
 
     provider = data_provider.TextDataProvider(dataset_dir=dataset_dir, annotation_name=annotation_name,
                                               validation_set=validation_split > 0, validation_split=validation_split,
-                                              shuffle='every_epoch', normalization=normalization.lower())
+                                              shuffle='every_epoch', normalization=normalization)
     print('done.')
 
     feature_io = data_utils.TextFeatureIO()


### PR DESCRIPTION
This PR adds annotation file name, validation split fraction and normalization mode to the command line arguments of write_text_features. It also completes some docstrings and has some minor cosmetic changes.