### PR TITLE
Add charmap generation to write_text_features

### DIFF
--- a/data_provider/data_provider.py
+++ b/data_provider/data_provider.py
@@ -165,13 +165,12 @@ class TextDataProvider(object):
         test_anno_path = ops.join(self.__test_dataset_dir, annotation_name)
         assert ops.exists(test_anno_path)
 
-        with open(test_anno_path, 'r') as anno_file:
+        with open(test_anno_path, 'r', encoding='utf-8') as anno_file:
             info = np.array([tmp.strip().split() for tmp in anno_file.readlines()])
 
             test_images_org = [cv2.imread(ops.join(self.__test_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                for tmp in info[:, 0]]
             test_images = np.array([cv2.resize(tmp, (100, 32)) for tmp in test_images_org])
-
 
             test_labels = np.array([tmp for tmp in info[:, 1]])
 
@@ -185,7 +184,7 @@ class TextDataProvider(object):
         train_anno_path = ops.join(self.__train_dataset_dir, annotation_name)
         assert ops.exists(train_anno_path)
 
-        with open(train_anno_path, 'r') as anno_file:
+        with open(train_anno_path, 'r', encoding='utf-8') as anno_file:
             info = np.array([tmp.strip().split() for tmp in anno_file.readlines()])
 
             train_images_org = [cv2.imread(ops.join(self.__train_dataset_dir, tmp), cv2.IMREAD_COLOR)
@@ -193,6 +192,7 @@ class TextDataProvider(object):
             train_images = np.array([cv2.resize(tmp,(100,32)) for tmp in train_images_org])
 
             train_labels = np.array([tmp for tmp in info[:, 1]])
+
             train_imagenames = np.array([ops.basename(tmp) for tmp in info[:, 0]])
 
             if validation_set is not None and validation_split is not None:

--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -23,8 +23,7 @@ class FeatureIO(object):
     """
         Implement the base writer class
     """
-    def __init__(self, char_dict_path=ops.join(os.getcwd(), 'data/char_dict/char_dict.json'),
-                 ord_map_dict_path=ops.join(os.getcwd(), 'data/char_dict/ord_map.json')):
+    def __init__(self, char_dict_path, ord_map_dict_path):
         self.__char_dict = establish_char_dict.CharDictBuilder.read_char_dict(char_dict_path)
         self.__ord_map = establish_char_dict.CharDictBuilder.read_ord_map_dict(ord_map_dict_path)
         return
@@ -158,8 +157,8 @@ class TextFeatureWriter(FeatureIO):
     """
         Implement the crnn feature writer
     """
-    def __init__(self):
-        super(TextFeatureWriter, self).__init__()
+    def __init__(self, char_dict_path, ord_map_dict_path):
+        super(TextFeatureWriter, self).__init__(char_dict_path, ord_map_dict_path)
         return
 
     def write_features(self, tfrecords_path, labels, images, imagenames):
@@ -198,8 +197,8 @@ class TextFeatureReader(FeatureIO):
     """
         Implement the crnn feature reader
     """
-    def __init__(self):
-        super(TextFeatureReader, self).__init__()
+    def __init__(self, char_dict_path, ord_map_dict_path):
+        super(TextFeatureReader, self).__init__(char_dict_path, ord_map_dict_path)
         return
 
     @staticmethod
@@ -234,12 +233,13 @@ class TextFeatureIO(object):
     """
         Implement a crnn feture io manager
     """
-    def __init__(self):
+    def __init__(self, char_dict_path=ops.join(os.getcwd(), 'data/char_dict/char_dict.json'),
+                 ord_map_dict_path=ops.join(os.getcwd(), 'data/char_dict/ord_map.json')):
         """
 
         """
-        self.__writer = TextFeatureWriter()
-        self.__reader = TextFeatureReader()
+        self.__writer = TextFeatureWriter(char_dict_path, ord_map_dict_path)
+        self.__reader = TextFeatureReader(char_dict_path, ord_map_dict_path)
         return
 
     @property

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -31,13 +31,14 @@ def init_args() -> argparse.Namespace:
     parser.add_argument('-s', '--save_dir', type=str, required=True,
                         help='Where to store the generated tfrecords')
     parser.add_argument('-a', '--annotation_file', type=str, default='sample.txt',
-                        help='Name of annotations file (in dataset_dir/Train and dataset_dir/Test)')
+                        help='Name of annotations file (in dataset_dir/Train and dataset_dir/Test). '
+                             'The encoding is assumed to be utf-8')
     parser.add_argument('-v', '--validation_split', type=float, default=0.15,
                         help='Fraction of training data to use for validation. Set to 0 to disable.')
     parser.add_argument('-n', '--normalization', type=str, default=None,
                         help="Perform normalization on images. Can be either 'divide_255' or 'divide_256'")
     parser.add_argument('-c', '--char_maps', type=str, default=None,
-                        help="Set the path where character maps will be saved from labels in training and test sets.")
+                        help='Set the path where character maps will be saved from labels in training and test sets.')
     return parser.parse_args()
 
 


### PR DESCRIPTION
This PR adds the option to automatically generate character maps from training and test data to write_text_features.py. Some naming inconsistencies are fixed and a few typing hints are added as well.

Things that might make sense for a related PR:
- ditch usage of json files altogether and using python files instead.
- store ord_map in reverse order

