### PR TITLE
using config options, cleanup and refactoring of training

### DIFF
--- a/crnn_model/crnn_model.py
+++ b/crnn_model/crnn_model.py
@@ -9,9 +9,8 @@
 Implement the crnn model mentioned in An End-to-End Trainable Neural Network for Image-based Sequence
 Recognition and Its Application to Scene Text Recognition paper
 """
-import numpy as np
+from typing import Tuple
 import tensorflow as tf
-from tensorflow.contrib import layers as tflayers
 from tensorflow.contrib import rnn
 
 from crnn_model import cnn_basenet
@@ -21,7 +20,7 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
     """
         Implement the crnn model for squence recognition
     """
-    def __init__(self, phase, hidden_nums, layers_nums, num_classes):
+    def __init__(self, phase: str, hidden_nums: int, layers_nums: int, num_classes: int):
         """
 
         :param phase: 'Train' or 'Test'
@@ -45,7 +44,7 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
         return self.__phase
 
     @phase.setter
-    def phase(self, value):
+    def phase(self, value: str):
         """
 
         :param value:
@@ -58,21 +57,21 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
         self.__phase = value.lower()
         return
 
-    def __conv_stage(self, inputdata, out_dims, name=None):
-        """
-        Traditional conv stage in VGG format
-        :param inputdata:
-        :param out_dims:
-        :return:
+    def __conv_stage(self, inputdata: tf.Tensor, out_dims: int, name: str=None) -> tf.Tensor:
+        """ Standard VGG convolutional stage: 2d conv, relu, and maxpool
+
+        :param inputdata: 4D tensor batch x width x height x channels
+        :param out_dims: number of output channels / filters
+        :return: the maxpooled output of the stage
         """
         conv = self.conv2d(inputdata=inputdata, out_channel=out_dims, kernel_size=3, stride=1, use_bias=False, name=name)
         relu = self.relu(inputdata=conv)
         max_pool = self.maxpooling(inputdata=relu, kernel_size=2, stride=2)
         return max_pool
 
-    def __feature_sequence_extraction(self, inputdata):
-        """
-        Implement the 2.1 Part Feature Sequence Extraction
+    def __feature_sequence_extraction(self, inputdata: tf.Tensor) -> tf.Tensor:
+        """ Implements section 2.1 of the paper: "Feature Sequence Extraction"
+
         :param inputdata: eg. batch*32*100*3 NHWC format
         :return:
         """
@@ -100,10 +99,11 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
         relu7 = self.relu(conv7)  # batch*1*25*512
         return relu7
 
-    def __map_to_sequence(self, inputdata):
-        """
-        Implement the map to sequence part of the network mainly used to convert the cnn feature map to sequence used in
-        later stacked lstm layers
+    def __map_to_sequence(self, inputdata: tf.Tensor) -> tf.Tensor:
+        """ Implements the map to sequence part of the network.
+
+        This is used to convert the CNN feature map to the sequence used in the stacked LSTM layers later on.
+        Note that this determines the lenght of the sequences that the LSTM expects
         :param inputdata:
         :return:
         """
@@ -111,9 +111,9 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
         assert shape[1] == 1  # H of the feature map must equal to 1
         return self.squeeze(inputdata=inputdata, axis=1)
 
-    def __sequence_label(self, inputdata):
-        """
-        Implement the sequence label part of the network
+    def __sequence_label(self, inputdata: tf.Tensor) -> Tuple[tf.Tensor, tf.Tensor]:
+        """ Implements the sequence label part of the network
+
         :param inputdata:
         :return:
         """
@@ -147,8 +147,8 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
 
         return rnn_out, raw_pred
 
-    def build_shadownet(self, inputdata):
-        """
+    def build_shadownet(self, inputdata: tf.Tensor) -> tf.Tensor:
+        """ Main routine to construct the network
 
         :param inputdata:
         :return:

--- a/crnn_model/crnn_model.py
+++ b/crnn_model/crnn_model.py
@@ -21,16 +21,18 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
     """
         Implement the crnn model for squence recognition
     """
-    def __init__(self, phase, hidden_nums, layers_nums, seq_length, num_classes):
+    def __init__(self, phase, hidden_nums, layers_nums, num_classes):
         """
 
-        :param phase:
+        :param phase: 'Train' or 'Test'
+        :param hidden_nums: Number of hidden units in each LSTM cell (block)
+        :param layers_nums: Number of LSTM cells (blocks)
+        :param num_classes: Number of classes (different symbols) to detect
         """
         super(ShadowNet, self).__init__()
         self.__phase = phase
         self.__hidden_nums = hidden_nums
         self.__layers_nums = layers_nums
-        self.__seq_length = seq_length
         self.__num_classes = num_classes
         return
 
@@ -118,9 +120,9 @@ class ShadowNet(cnn_basenet.CNNBaseModel):
         with tf.variable_scope('LSTMLayers'):
             # construct stack lstm rcnn layer
             # forward lstm cell
-            fw_cell_list = [rnn.BasicLSTMCell(nh, forget_bias=1.0) for nh in [self.__hidden_nums, self.__hidden_nums]]
+            fw_cell_list = [rnn.BasicLSTMCell(nh, forget_bias=1.0) for nh in [self.__hidden_nums]*self.__layers_nums]
             # Backward direction cells
-            bw_cell_list = [rnn.BasicLSTMCell(nh, forget_bias=1.0) for nh in [self.__hidden_nums, self.__hidden_nums]]
+            bw_cell_list = [rnn.BasicLSTMCell(nh, forget_bias=1.0) for nh in [self.__hidden_nums]*self.__layers_nums]
 
             stack_lstm_layer, _, _ = rnn.stack_bidirectional_dynamic_rnn(fw_cell_list, bw_cell_list, inputdata,
                                                                          dtype=tf.float32)

--- a/data_provider/data_provider.py
+++ b/data_provider/data_provider.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     pass
 
+from global_configuration import config
 from data_provider import base_data_provider
 
 
@@ -170,7 +171,7 @@ class TextDataProvider(object):
 
             test_images_org = [cv2.imread(ops.join(self.__test_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                for tmp in info[:, 0]]
-            test_images = np.array([cv2.resize(tmp, (100, 32)) for tmp in test_images_org])
+            test_images = np.array([cv2.resize(tmp, config.cfg.ARCH.INPUT_SIZE) for tmp in test_images_org])
 
             test_labels = np.array([tmp for tmp in info[:, 1]])
 
@@ -189,7 +190,7 @@ class TextDataProvider(object):
 
             train_images_org = [cv2.imread(ops.join(self.__train_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                      for tmp in info[:, 0]]
-            train_images = np.array([cv2.resize(tmp,(100,32)) for tmp in train_images_org])
+            train_images = np.array([cv2.resize(tmp, config.cfg.ARCH.INPUT_SIZE) for tmp in train_images_org])
 
             train_labels = np.array([tmp for tmp in info[:, 1]])
 

--- a/data_provider/data_provider.py
+++ b/data_provider/data_provider.py
@@ -171,7 +171,8 @@ class TextDataProvider(object):
         assert ops.exists(test_anno_path)
 
         with open(test_anno_path, 'r', encoding='utf-8') as anno_file:
-            info = np.array([tmp.strip().split() for tmp in anno_file.readlines()])
+            info = np.array(list(filter(lambda x: len(x) == 2,  # discard bogus entries with no label
+                                        [tmp.strip().split(maxsplit=1) for tmp in anno_file.readlines()])))
 
             test_images_org = [cv2.imread(ops.join(self.__test_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                for tmp in info[:, 0]]
@@ -183,14 +184,14 @@ class TextDataProvider(object):
 
             self.test = TextDataset(test_images, test_labels, imagenames=test_imagenames,
                                     shuffle=shuffle, normalization=normalization)
-        anno_file.close()
 
         # add train and validation dataset
         train_anno_path = ops.join(self.__train_dataset_dir, annotation_name)
         assert ops.exists(train_anno_path)
 
         with open(train_anno_path, 'r', encoding='utf-8') as anno_file:
-            info = np.array([tmp.strip().split() for tmp in anno_file.readlines()])
+            info = np.array(list(filter(lambda x: len(x) == 2,  # discard bogus entries with no label
+                                        [tmp.strip().split(maxsplit=1) for tmp in anno_file.readlines()])))
 
             train_images_org = [cv2.imread(ops.join(self.__train_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                      for tmp in info[:, 0]]
@@ -214,8 +215,6 @@ class TextDataProvider(object):
 
             if validation_set and not validation_split:
                 self.validation = self.test
-        anno_file.close()
-        return
 
     def __str__(self):
         provider_info = 'Dataset_dir: {:s} contain training images: {:d} validation images: {:d} testing images: {:d}'.\

--- a/data_provider/data_provider.py
+++ b/data_provider/data_provider.py
@@ -9,6 +9,8 @@
 Provide the training and testing data for shadow net
 """
 import os.path as ops
+from typing import Tuple
+
 import numpy as np
 import copy
 import cv2
@@ -133,7 +135,7 @@ class TextDataProvider(object):
         Implement the text data provider for training and testing the shadow net
     """
     def __init__(self, dataset_dir, annotation_name, validation_set=None, validation_split=None, shuffle=None,
-                 normalization=None):
+                 normalization=None, input_size: Tuple[int, int]=None):
         """
 
         :param dataset_dir: str, where you save the dataset one class on folder
@@ -150,7 +152,9 @@ class TextDataProvider(object):
                               'divide_256': divide all pixels by 256
                               'by_chanels': substract mean of every chanel and divide each
                                             chanel data by it's standart deviation
+        :param input_size: Target size to which all images will be resized.
         """
+        self.__input_size = input_size if input_size is not None else config.cfg.ARCH.INPUT_SIZE
         self.__dataset_dir = dataset_dir
         self.__validation_split = validation_split
         self.__shuffle = shuffle
@@ -171,7 +175,7 @@ class TextDataProvider(object):
 
             test_images_org = [cv2.imread(ops.join(self.__test_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                for tmp in info[:, 0]]
-            test_images = np.array([cv2.resize(tmp, config.cfg.ARCH.INPUT_SIZE) for tmp in test_images_org])
+            test_images = np.array([cv2.resize(tmp, self.__input_size) for tmp in test_images_org])
 
             test_labels = np.array([tmp for tmp in info[:, 1]])
 
@@ -190,7 +194,7 @@ class TextDataProvider(object):
 
             train_images_org = [cv2.imread(ops.join(self.__train_dataset_dir, tmp), cv2.IMREAD_COLOR)
                                      for tmp in info[:, 0]]
-            train_images = np.array([cv2.resize(tmp, config.cfg.ARCH.INPUT_SIZE) for tmp in train_images_org])
+            train_images = np.array([cv2.resize(tmp, self.__input_size) for tmp in train_images_org])
 
             train_labels = np.array([tmp for tmp in info[:, 1]])
 
@@ -217,6 +221,14 @@ class TextDataProvider(object):
         provider_info = 'Dataset_dir: {:s} contain training images: {:d} validation images: {:d} testing images: {:d}'.\
             format(self.__dataset_dir, self.train.num_examples, self.validation.num_examples, self.test.num_examples)
         return provider_info
+
+    @property
+    def input_size(self):
+        """ Size to which images are rescaled before training and testing.
+
+        :return:
+        """
+        return self.__input_size
 
     @property
     def dataset_dir(self):

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -22,11 +22,9 @@ __C.ARCH.HIDDEN_UNITS = 256
 # Number of stacked LSTM cells
 __C.ARCH.HIDDEN_LAYERS = 2
 # Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4
-__C.ARCH.SEQ_LENGTH = 25
-# Set to 27 for letters, 37 for letters/numbers, 47 for letters/numbers/special_chars
-__C.ARCH.NUM_CLASSES = 47
+__C.ARCH.SEQ_LENGTH = 32
 # Width x height into which training / testing images are resized before feeding into the network
-__C.ARCH.INPUT_SIZE = (100, 32)
+__C.ARCH.INPUT_SIZE = (128, 32)
 
 # Train options
 __C.TRAIN = edict()

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -24,7 +24,7 @@ __C.ARCH.HIDDEN_LAYERS = 2
 # Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4
 __C.ARCH.SEQ_LENGTH = 32
 # Width x height into which training / testing images are resized before feeding into the network
-__C.ARCH.INPUT_SIZE = (128, 32)
+__C.ARCH.INPUT_SIZE = (100, 32)
 
 # Train options
 __C.TRAIN = edict()

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -22,7 +22,7 @@ __C.ARCH.HIDDEN_UNITS = 256
 # Number of stacked LSTM cells
 __C.ARCH.HIDDEN_LAYERS = 2
 # Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4
-__C.ARCH.SEQ_LENGTH = 32
+__C.ARCH.SEQ_LENGTH = 25
 # Width x height into which training / testing images are resized before feeding into the network
 __C.ARCH.INPUT_SIZE = (100, 32)
 

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -15,6 +15,17 @@ __C = edict()
 
 cfg = __C
 
+__C.ARCH = edict()
+
+# Number of units in each LSTM cell
+__C.ARCH.HIDDEN_UNITS = 256
+# Number of stacked LSTM cells
+__C.ARCH.HIDDEN_LAYERS = 2
+# Sequence length
+__C.ARCH.SEQ_LENGTH = 25
+# Set to 27 for letters, 37 for letters/numbers, 47 for letters/numbers/special_chars
+__C.ARCH.NUM_CLASSES = 47
+
 # Train options
 __C.TRAIN = edict()
 

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -21,7 +21,7 @@ __C.ARCH = edict()
 __C.ARCH.HIDDEN_UNITS = 256
 # Number of stacked LSTM cells
 __C.ARCH.HIDDEN_LAYERS = 2
-# Sequence length
+# Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4
 __C.ARCH.SEQ_LENGTH = 25
 # Set to 27 for letters, 37 for letters/numbers, 47 for letters/numbers/special_chars
 __C.ARCH.NUM_CLASSES = 47

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -25,6 +25,8 @@ __C.ARCH.HIDDEN_LAYERS = 2
 __C.ARCH.SEQ_LENGTH = 25
 # Set to 27 for letters, 37 for letters/numbers, 47 for letters/numbers/special_chars
 __C.ARCH.NUM_CLASSES = 47
+# Width x height into which training / testing images are resized before feeding into the network
+__C.ARCH.INPUT_SIZE = (100, 32)
 
 # Train options
 __C.TRAIN = edict()

--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -16,6 +16,7 @@ import os
 import os.path as ops
 import sys
 
+from global_configuration import config
 from local_utils import establish_char_dict
 
 
@@ -222,7 +223,8 @@ class TextFeatureReader(FeatureIO):
                                                'labels': tf.VarLenFeature(tf.int64),
                                            })
         image = tf.decode_raw(features['images'], tf.uint8)
-        images = tf.reshape(image, [32, 100, 3])
+        w, h = config.cfg.ARCH.INPUT_SIZE
+        images = tf.reshape(image, [h, w, 3])
         labels = features['labels']
         labels = tf.cast(labels, tf.int32)
         imagenames = features['imagenames']

--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -231,7 +231,7 @@ class TextFeatureReader(FeatureIO):
 
 class TextFeatureIO(object):
     """
-        Implement a crnn feture io manager
+        Implement a crnn feature io manager
     """
     def __init__(self, char_dict_path=ops.join(os.getcwd(), 'data/char_dict/char_dict.json'),
                  ord_map_dict_path=ops.join(os.getcwd(), 'data/char_dict/ord_map.json')):

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -54,14 +54,15 @@ def recognize(image_path, weights_path, is_vis=True):
 
     inputdata = tf.placeholder(dtype=tf.float32, shape=[1, 32, 100, 3], name='input')
 
-    net = crnn_model.ShadowNet(phase='Test', hidden_nums=256, layers_nums=2, seq_length=25, num_classes=37)
+    decoder = data_utils.TextFeatureIO()
+
+    net = crnn_model.ShadowNet(phase='Test', hidden_nums=256, layers_nums=2, seq_length=25,
+                               num_classes=len(decoder.char_dict))
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=inputdata)
 
     decodes, _ = tf.nn.ctc_beam_search_decoder(inputs=net_out, sequence_length=25*np.ones(1), merge_repeated=False)
-
-    decoder = data_utils.TextFeatureIO()
 
     # config tf session
     sess_config = tf.ConfigProto()

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -56,13 +56,16 @@ def recognize(image_path, weights_path, is_vis=True):
 
     decoder = data_utils.TextFeatureIO()
 
-    net = crnn_model.ShadowNet(phase='Test', hidden_nums=256, layers_nums=2, seq_length=25,
+    net = crnn_model.ShadowNet(phase='Test',
+                               hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
+                               layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
                                num_classes=len(decoder.char_dict))
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=inputdata)
 
-    decodes, _ = tf.nn.ctc_beam_search_decoder(inputs=net_out, sequence_length=25*np.ones(1), merge_repeated=False)
+    decodes, _ = tf.nn.ctc_beam_search_decoder(inputs=net_out, sequence_length=config.cfg.ARCH.SEQ_LENGTH*np.ones(1),
+                                               merge_repeated=False)
 
     # config tf session
     sess_config = tf.ConfigProto()

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -48,7 +48,6 @@ def recognize(image_path, weights_path, is_vis=True):
     :param is_vis:
     :return:
     """
-    decoder = data_utils.TextFeatureIO()
 
     image = cv2.imread(image_path, cv2.IMREAD_COLOR)
     image = cv2.resize(image, config.cfg.ARCH.INPUT_SIZE)

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -48,6 +48,8 @@ def recognize(image_path, weights_path, is_vis=True):
     :param is_vis:
     :return:
     """
+    decoder = data_utils.TextFeatureIO()
+
     image = cv2.imread(image_path, cv2.IMREAD_COLOR)
     image = cv2.resize(image, config.cfg.ARCH.INPUT_SIZE)
     image = np.expand_dims(image, axis=0).astype(np.float32)
@@ -60,7 +62,7 @@ def recognize(image_path, weights_path, is_vis=True):
     net = crnn_model.ShadowNet(phase='Test',
                                hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
                                layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
-                               num_classes=len(decoder.char_dict))
+                               num_classes=len(decoder.char_dict) + 1)
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=inputdata)

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -49,10 +49,11 @@ def recognize(image_path, weights_path, is_vis=True):
     :return:
     """
     image = cv2.imread(image_path, cv2.IMREAD_COLOR)
-    image = cv2.resize(image, (100, 32))
+    image = cv2.resize(image, config.cfg.ARCH.INPUT_SIZE)
     image = np.expand_dims(image, axis=0).astype(np.float32)
 
-    inputdata = tf.placeholder(dtype=tf.float32, shape=[1, 32, 100, 3], name='input')
+    w, h = config.cfg.ARCH.INPUT_SIZE
+    inputdata = tf.placeholder(dtype=tf.float32, shape=[1, h, w, 3], name='input')
 
     decoder = data_utils.TextFeatureIO()
 

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -57,7 +57,8 @@ def test_shadownet(dataset_dir, weights_path, is_vis=False, is_recursive=True):
     images_sh = tf.cast(x=images_sh, dtype=tf.float32)
 
     # build shadownet
-    net = crnn_model.ShadowNet(phase='Test', hidden_nums=256, layers_nums=2, seq_length=25, num_classes=37)
+    net = crnn_model.ShadowNet(phase='Test', hidden_nums=256, layers_nums=2, seq_length=25,
+                               num_classes=len(decoder.char_dict))
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=images_sh)

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -65,7 +65,7 @@ def test_shadownet(dataset_dir, weights_path, is_vis=False, is_recursive=True, n
     # build shadownet
     net = crnn_model.ShadowNet(phase='Test', hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
                                layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
-                               num_classes=len(decoder.char_dict)+1)
+                               num_classes=len(decoder.char_dict) + 1)
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=images_sh)

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -65,7 +65,7 @@ def test_shadownet(dataset_dir, weights_path, is_vis=False, is_recursive=True, n
     # build shadownet
     net = crnn_model.ShadowNet(phase='Test', hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
                                layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
-                               num_classes=len(decoder.char_dict))
+                               num_classes=len(decoder.char_dict)+1)
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=images_sh)

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -8,6 +8,7 @@
 """
 Test shadow net script
 """
+import os
 import os.path as ops
 import tensorflow as tf
 import matplotlib.pyplot as plt
@@ -26,9 +27,11 @@ def init_args():
     :return:
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('--dataset_dir', type=str, help='Path to test tfrecords data')
-    parser.add_argument('--weights_path', type=str, help='Path to pretrained weights')
-    parser.add_argument('--is_recursive', type=bool, help='Whether to recursively test the dataset')
+    parser.add_argument('-d', '--dataset_dir', type=str, help='Path to test tfrecords data')
+    parser.add_argument('-w', '--weights_path', type=str, help='Path to pre-trained weights')
+    parser.add_argument('-r', '--is_recursive', type=bool, help='Whether to recursively test the dataset')
+    parser.add_argument('-j', '--num_threads', type=int, default=int(os.cpu_count() / 2),
+                        help='Number of threads to use in batch shuffling')
 
     return parser.parse_args()
 
@@ -183,4 +186,4 @@ if __name__ == '__main__':
     args = init_args()
 
     # test shadow net
-    test_shadownet(args.dataset_dir, args.weights_path, args.is_recursive)
+    test_shadownet(args.dataset_dir, args.weights_path, args.is_recursive, args.num_threads)

--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -52,8 +52,8 @@ def train_shadownet(dataset_dir, weights_path=None):
     inputdata = tf.cast(x=inputdata, dtype=tf.float32)
 
     # initialise the net model
-    # Set num_classes to 27 for letters, 37 for letters/numbers, 47 for letters/numbers/special_chars
-    shadownet = crnn_model.ShadowNet(phase='Train', hidden_nums=256, layers_nums=2, seq_length=25, num_classes=47)
+    shadownet = crnn_model.ShadowNet(phase='Train', hidden_nums=256, layers_nums=2, seq_length=25,
+                                     num_classes=len(decoder.char_dict))
 
     with tf.variable_scope('shadow', reuse=False):
         net_out = shadownet.build_shadownet(inputdata=inputdata)

--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -29,8 +29,9 @@ def init_args():
     :return:
     """
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--dataset_dir', type=str, help='Path to dir containing train/test data and annotation files.')
-    parser.add_argument('-w', '--weights_path', type=str, help='Path to pretrained weights.')
+    parser.add_argument('-d', '--dataset_dir', type=str,
+                        help='Path to dir containing train/test data and annotation files.')
+    parser.add_argument('-w', '--weights_path', type=str, help='Path to pre-trained weights.')
     parser.add_argument('-j', '--num_threads', type=int, default=int(os.cpu_count()/2),
                         help='Number of threads to use in batch shuffling')
 
@@ -179,5 +180,5 @@ if __name__ == '__main__':
     if not ops.exists(args.dataset_dir):
         raise ValueError('{:s} doesn\'t exist'.format(args.dataset_dir))
 
-    train_shadownet(args.dataset_dir, args.weights_path)
+    train_shadownet(args.dataset_dir, args.weights_path, args.num_threads)
     print('Done')

--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -60,7 +60,7 @@ def train_shadownet(dataset_dir, weights_path=None, num_threads=4):
     shadownet = crnn_model.ShadowNet(phase='Train',
                                      hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
                                      layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
-                                     num_classes=len(decoder.char_dict))
+                                     num_classes=len(decoder.char_dict)+1)
 
     with tf.variable_scope('shadow', reuse=False):
         net_out = shadownet.build_shadownet(inputdata=inputdata)

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -73,7 +73,8 @@ def write_features(dataset_dir: str, save_dir: str, annotation_name: str, valida
     print('Writing tf records for training...')
 
     train_images = provider.train.images
-    train_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in train_images]
+    w, h = provider.input_size
+    train_images = [bytes(list(np.reshape(tmp, [w * h * 3]))) for tmp in train_images]
     train_labels = provider.train.labels
     train_imagenames = provider.train.imagenames
 
@@ -93,7 +94,7 @@ def write_features(dataset_dir: str, save_dir: str, annotation_name: str, valida
     print('Writing tf records for testing...')
 
     test_images = provider.test.images
-    test_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in test_images]
+    test_images = [bytes(list(np.reshape(tmp, [w * h * 3]))) for tmp in test_images]
     test_labels = provider.test.labels
     test_imagenames = provider.test.imagenames
 
@@ -113,7 +114,7 @@ def write_features(dataset_dir: str, save_dir: str, annotation_name: str, valida
     print('Writing tf records for validation...')
 
     val_images = provider.validation.images
-    val_images = [bytes(list(np.reshape(tmp, [100 * 32 * 3]))) for tmp in val_images]
+    val_images = [bytes(list(np.reshape(tmp, [w * h * 3]))) for tmp in val_images]
     val_labels = provider.validation.labels
     val_imagenames = provider.validation.imagenames
 

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -93,7 +93,7 @@ if __name__ == '__main__':
 
     print('Initializing the dataset provider... ', end='', flush=True)
 
-    provider = data_provider.TextDataProvider(dataset_dir=args.dataset_dir, annotation_name=args.annotation_name,
+    provider = data_provider.TextDataProvider(dataset_dir=args.dataset_dir, annotation_name=args.annotation_file,
                                               validation_set=args.validation_split > 0,
                                               validation_split=args.validation_split, shuffle='every_epoch',
                                               normalization=args.normalization)

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -13,6 +13,7 @@ import os.path as ops
 import argparse
 from functools import reduce
 import numpy as np
+from global_configuration import config
 
 from data_provider import data_provider
 from data_provider.data_provider import TextDataset
@@ -96,7 +97,7 @@ if __name__ == '__main__':
     provider = data_provider.TextDataProvider(dataset_dir=args.dataset_dir, annotation_name=args.annotation_file,
                                               validation_set=args.validation_split > 0,
                                               validation_split=args.validation_split, shuffle='every_epoch',
-                                              normalization=args.normalization)
+                                              normalization=args.normalization, input_size=config.cfg.ARCH.INPUT_SIZE)
     print('done.')
 
     write_tfrecords(provider.train, "train", args.save_dir, args.char_maps)

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -50,12 +50,12 @@ def write_tfrecords(dataset: TextDataset, name: str, save_dir: str, char_maps_di
     :param save_dir: Where to store the tf records
     :param char_maps_dir: If not None, extract character maps from labels and merge with any char_dict already present
     """
-    tfrecord_path = ops.join(save_dir, '%s_features.tfrecords' % name)
+    tfrecord_path = ops.join(save_dir, '%s_feature.tfrecords' % name)
     print('Writing tf records for %s at %s...' % (name, tfrecord_path))
 
     images = dataset.images
-    h, w = dataset.images.shape
-    images = [bytes(list(np.reshape(tmp, [w * h * 3]))) for tmp in images]
+    h, w, c = images.shape[1:]  # shape is num samples x height x width x num channels
+    images = [bytes(list(np.reshape(tmp, [w * h * c]))) for tmp in images]
     labels = dataset.labels
     imagenames = dataset.imagenames
 


### PR DESCRIPTION
There are many changes in this PR (sorry about that, it was hard to split it. If you need it, I could try some other day). Basically it is about:

* `config.py`: add ARCH configuration section with hidden units, layers, sequence length and image size
* `data_utils.py`: use ARCH configuration values
* `(demo|test|train)_shadownet.py`: use ARCH configuration values
* `train_shadownet.py`: add num_threads command line argument for queued batch generation.
* `write_text_features.py`: refactor and simplify code, use ARCH configuration for defaults
* `crnn_model.py`: comments, type hints, actually use all config parameters (e.g. num LSTM layers)
* `data_provider.py`: refactor code, make input_size a parameter
