### PR TITLE
Solved "No valid path found" when calculating loss

### DIFF
--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -21,7 +21,7 @@ __C.ARCH = edict()
 __C.ARCH.HIDDEN_UNITS = 256
 # Number of stacked LSTM cells
 __C.ARCH.HIDDEN_LAYERS = 2
-# Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4 * 2
+# Sequence length.  This has to be the width of the final output CRNN network, which is input size width / 4 * 2
 __C.ARCH.SEQ_LENGTH = 25 * 2
 # Width x height into which training / testing images are resized before feeding into the network
 __C.ARCH.INPUT_SIZE = (100, 32)

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -21,8 +21,8 @@ __C.ARCH = edict()
 __C.ARCH.HIDDEN_UNITS = 256
 # Number of stacked LSTM cells
 __C.ARCH.HIDDEN_LAYERS = 2
-# Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4
-__C.ARCH.SEQ_LENGTH = 25
+# Sequence length.  This has to be the width of the final feature map of the CNN, which is input size width / 4 * 2
+__C.ARCH.SEQ_LENGTH = 25 * 2
 # Width x height into which training / testing images are resized before feeding into the network
 __C.ARCH.INPUT_SIZE = (100, 32)
 


### PR DESCRIPTION
Solved "Error: W tensorflow/core/util/ctc/ctc_loss_calculator.cc:144] No valid path found." bug.

"No valid path found" message is printed because of not enough time steps. The dimension of CRNN output is not (25, 32, num_class), but (50, 32, num_class). Thus, if sequence length is 25, ctc will not find the proper path to long range label. With "__C.ARCH.SEQ_LENGTH = 25", the accuracy of predicting long length label can be low.

Thanks to your contribution.