### PR TITLE
Support for different config files, fix some issues in test_shadownet

### DIFF
--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -8,8 +8,11 @@
 """
 Test shadow net script
 """
+import importlib
 import os
 import os.path as ops
+import sys
+
 import tensorflow as tf
 import matplotlib.pyplot as plt
 import argparse
@@ -192,8 +195,15 @@ if __name__ == '__main__':
     args = init_args()
 
     if args.config_file:
-        import importlib
-        config = importlib.import_module(args.config_file)
+        # Remove extension in case the user gave it
+        args.config_file = os.path.splitext(args.config_file)[0]
+
+        module = os.path.basename(args.config_file)
+        path = os.path.abspath(os.path.dirname(args.config_file))
+        sys.path = [path] + sys.path  # Search here first
+        config = importlib.import_module(module)
+    else:
+        config = importlib.import_module("global_configuration.config")
 
     test_shadownet(dataset_dir=args.dataset_dir, weights_path=args.weights_path,
                    cfg=config.cfg, is_recursive=args.is_recursive,

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -30,9 +30,9 @@ def init_args() -> argparse.Namespace:
                         help='Path to test tfrecords data')
     parser.add_argument('-w', '--weights_path', type=str, required=True,
                         help='Path to pre-trained weights')
-    parser.add_argument('-r', '--is_recursive', type=bool,
+    parser.add_argument('-r', '--is_recursive', type=bool, default=False,
                         help='Whether to recursively test the dataset')
-    parser.add_argument('-c', '--num_classes', type=int,
+    parser.add_argument('-c', '--num_classes', type=int, required=True,
                         help='Force number of character classes to this number. '
                              'Use 37 to run with the demo data.')
     parser.add_argument('-f', '--config_file', type=str,

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -38,7 +38,7 @@ def init_args() -> argparse.Namespace:
                         help='Use this global configuration file')
     parser.add_argument('-v', '--visualise', type=bool, default=False,
                         help='Whether to display images')
-    parser.add_argument('-b', '--one_batch', type=bool, default=False,
+    parser.add_argument('-b', '--one_batch', default=False,
                         action='store_true', help='Test only one batch of the dataset')
     parser.add_argument('-j', '--num_threads', type=int,
                         default=int(os.cpu_count() / 2),

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -18,14 +18,10 @@ import math
 
 from local_utils import data_utils
 from crnn_model import crnn_model
-from global_configuration import config
+from easydict import EasyDict
 
 
-def init_args():
-    """
-
-    :return:
-    """
+def init_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--dataset_dir', type=str, required=True,
                         help='Path to test tfrecords data')
@@ -33,26 +29,29 @@ def init_args():
                         help='Path to pre-trained weights')
     parser.add_argument('-r', '--is_recursive', type=bool,
                         help='Whether to recursively test the dataset')
-    parser.add_argument('-c', '--num_classes', type=int, required=True,
+    parser.add_argument('-c', '--num_classes', type=int,
                         help='Force number of character classes to this number. '
                              'Use 37 to run with the demo data.')
-    parser.add_argument('-j', '--num_threads', type=int, default=int(os.cpu_count() / 2),
+    parser.add_argument('-f', '--config_file', type=str,
+                        help='Use this global configuration file')
+    parser.add_argument('-j', '--num_threads', type=int,
+                        default=int(os.cpu_count() / 2),
                         help='Number of threads to use in batch shuffling')
 
     return parser.parse_args()
 
 
-def test_shadownet(dataset_dir: str, weights_path: str, is_vis: bool = False,
-                   is_recursive: bool = True, num_threads: int = 4,
-                   num_classes: int = None):
+def test_shadownet(dataset_dir: str, weights_path: str, cfg: EasyDict, is_vis: bool=False,
+                   is_recursive: bool=True, num_threads: int=4, num_classes: int=None):
     """
 
     :param dataset_dir:
     :param weights_path:
-    :param is_vis:
+    :param cfg: configuration EasyDict (e.g. global_config.config.cfg)
+    :param is_vis: whether to visualise the result
     :param is_recursive:
-    :param num_threads:
-    :param num_classes:
+    :param num_threads: Number of threads for tf.train.(shuffle_)batch
+    :param num_classes: Number of different characters in the dataset
     """
     # Initialize the record decoder
     decoder = data_utils.TextFeatureIO().reader
@@ -60,34 +59,34 @@ def test_shadownet(dataset_dir: str, weights_path: str, is_vis: bool = False,
         ops.join(dataset_dir, 'test_feature.tfrecords'), num_epochs=None)
     if not is_recursive:
         images_sh, labels_sh, imagenames_sh = tf.train.shuffle_batch(tensors=[images_t, labels_t, imagenames_t],
-                                                                     batch_size=config.cfg.TEST.BATCH_SIZE,
-                                                                     capacity=1000 + 2 * config.cfg.TEST.BATCH_SIZE,
+                                                                     batch_size=cfg.TEST.BATCH_SIZE,
+                                                                     capacity=1000 + 2*cfg.TEST.BATCH_SIZE,
                                                                      min_after_dequeue=2, num_threads=num_threads)
     else:
         images_sh, labels_sh, imagenames_sh = tf.train.batch(tensors=[images_t, labels_t, imagenames_t],
-                                                             batch_size=config.cfg.TEST.BATCH_SIZE,
-                                                             capacity=1000 + 2 * config.cfg.TEST.BATCH_SIZE,
+                                                             batch_size=cfg.TEST.BATCH_SIZE,
+                                                             capacity=1000 + 2 * cfg.TEST.BATCH_SIZE,
                                                              num_threads=num_threads)
 
     images_sh = tf.cast(x=images_sh, dtype=tf.float32)
 
     # build shadownet
     num_classes = len(decoder.char_dict) + 1 if num_classes is None else num_classes
-    net = crnn_model.ShadowNet(phase='Test', hidden_nums=config.cfg.ARCH.HIDDEN_UNITS,
-                               layers_nums=config.cfg.ARCH.HIDDEN_LAYERS,
+    net = crnn_model.ShadowNet(phase='Test', hidden_nums=cfg.ARCH.HIDDEN_UNITS,
+                               layers_nums=cfg.ARCH.HIDDEN_LAYERS,
                                num_classes=num_classes)
 
     with tf.variable_scope('shadow'):
         net_out = net.build_shadownet(inputdata=images_sh)
 
     decoded, _ = tf.nn.ctc_beam_search_decoder(net_out,
-                                               config.cfg.ARCH.SEQ_LENGTH * np.ones(config.cfg.TEST.BATCH_SIZE),
+                                               cfg.ARCH.SEQ_LENGTH * np.ones(cfg.TEST.BATCH_SIZE),
                                                merge_repeated=False)
 
     # config tf session
     sess_config = tf.ConfigProto()
-    sess_config.gpu_options.per_process_gpu_memory_fraction = config.cfg.TRAIN.GPU_MEMORY_FRACTION
-    sess_config.gpu_options.allow_growth = config.cfg.TRAIN.TF_ALLOW_GROWTH
+    sess_config.gpu_options.per_process_gpu_memory_fraction = cfg.TRAIN.GPU_MEMORY_FRACTION
+    sess_config.gpu_options.allow_growth = cfg.TRAIN.TF_ALLOW_GROWTH
 
     # config tf saver
     saver = tf.train.Saver()
@@ -97,7 +96,7 @@ def test_shadownet(dataset_dir: str, weights_path: str, is_vis: bool = False,
     test_sample_count = 0
     for record in tf.python_io.tf_record_iterator(ops.join(dataset_dir, 'test_feature.tfrecords')):
         test_sample_count += 1
-    loops_nums = int(math.ceil(test_sample_count / config.cfg.TEST.BATCH_SIZE))
+    loops_nums = int(math.ceil(test_sample_count / cfg.TEST.BATCH_SIZE))
     # loops_nums = 100
 
     with sess.as_default():
@@ -187,13 +186,15 @@ def test_shadownet(dataset_dir: str, weights_path: str, is_vis: bool = False,
         coord.request_stop()
         coord.join(threads=threads)
 
-    sess.close()
-    return
-
 
 if __name__ == '__main__':
-    # init args
+
     args = init_args()
 
-    # test shadow net
-    test_shadownet(args.dataset_dir, args.weights_path, args.is_recursive, args.num_threads, args.num_classes)
+    if args.config_file:
+        import importlib
+        config = importlib.import_module(args.config_file)
+
+    test_shadownet(dataset_dir=args.dataset_dir, weights_path=args.weights_path,
+                   cfg=config.cfg, is_recursive=args.is_recursive,
+                   num_threads=args.num_threads, num_classes=args.num_classes)

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -200,13 +200,21 @@ if __name__ == '__main__':
     if args.config_file:
         # Remove extension in case the user gave it
         args.config_file = os.path.splitext(args.config_file)[0]
-
-        module = os.path.basename(args.config_file)
         path = os.path.abspath(os.path.dirname(args.config_file))
-        sys.path = [path] + sys.path  # Search here first
-        config = importlib.import_module(module)
+        module = os.path.basename(args.config_file)
     else:
-        config = importlib.import_module("global_configuration.config")
+        path = "."
+        module = "global_configuration.config"
+
+    try:
+        save_path = sys.path
+        sys.path = [path] + sys.path  # Search here first
+        print("Importing configuration {:s} from {:s}".format(module, path))
+        config = importlib.import_module(module)
+        sys.path = save_path
+    except:
+        print("Configuration file not found or invalid")
+        exit(1)
 
     test_shadownet(dataset_dir=args.dataset_dir, weights_path=args.weights_path,
                    cfg=config.cfg, process_all_data=not args.one_batch,

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -48,7 +48,7 @@ def init_args() -> argparse.Namespace:
 
 
 def test_shadownet(dataset_dir: str, weights_path: str, cfg: EasyDict, is_vis: bool,
-                   process_all_data: bool=True, num_threads: int=4, num_classes: int=None):
+                   process_all_data: bool=True, num_threads: int=4, num_classes: int=0):
     """
 
     :param dataset_dir:
@@ -77,7 +77,7 @@ def test_shadownet(dataset_dir: str, weights_path: str, cfg: EasyDict, is_vis: b
     images_sh = tf.cast(x=images_sh, dtype=tf.float32)
 
     # build shadownet
-    num_classes = len(decoder.char_dict) + 1 if num_classes is None else num_classes
+    num_classes = len(decoder.char_dict) + 1 if num_classes == 0 else num_classes
     net = crnn_model.ShadowNet(phase='Test', hidden_nums=cfg.ARCH.HIDDEN_UNITS,
                                layers_nums=cfg.ARCH.HIDDEN_LAYERS,
                                num_classes=num_classes)


### PR DESCRIPTION
This PR addresses #136  and related issues due to missing `num_classes`. It also adds support for specifying different configuration files during testing. This is required in addition to the saved weights when trying different architectures.