### PR TITLE
Making charsets configurable

### DIFF
--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -235,10 +235,8 @@ class TextFeatureIO(object):
     """
         Implement a crnn feature io manager
     """
-    def __init__(self, char_dict_path=ops.join(os.getcwd(), 'data/char_dict/char_dict.json'),
-                 ord_map_dict_path=ops.join(os.getcwd(), 'data/char_dict/ord_map.json')):
+    def __init__(self, char_dict_path, ord_map_dict_path):
         """
-
         """
         self.__writer = TextFeatureWriter(char_dict_path, ord_map_dict_path)
         self.__reader = TextFeatureReader(char_dict_path, ord_map_dict_path)

--- a/local_utils/establish_char_dict.py
+++ b/local_utils/establish_char_dict.py
@@ -43,7 +43,7 @@ class CharDictBuilder(object):
             raise ValueError('save path {:s} should be a json file'.format(save_path))
         os.makedirs(ops.dirname(save_path), exist_ok=True)
         with open(save_path, 'w', encoding='utf-8') as json_f:
-            json.dump(data, json_f)
+            json.dump(data, json_f, sort_keys=True, indent=4)
 
     @staticmethod
     def write_char_dict(origin_char_list: Union[str, List, Set], save_path: str):

--- a/tools/demo_shadownet.py
+++ b/tools/demo_shadownet.py
@@ -36,17 +36,21 @@ def init_args() -> argparse.Namespace:
                         default='data/test_images/test_01.jpg')
     parser.add_argument('--weights_path', type=str, help='Where you store the weights',
                         default='model/shadownet/shadownet_2017-09-29-19-16-33.ckpt-39999')
-    parser.add_argument('-c', '--num_classes', type=int, default=37,
-                        help='Force number of character classes to this number. Set to 0 for auto.')
+    parser.add_argument('-c', '--charset_dir', type=str, default='data/char_dict',
+                        help='Path to dir where character sets for the dataset were stored')
+    parser.add_argument('-n', '--num_classes', type=int, default=37,
+                        help='Force number of character classes to this number. '
+                             'Set to 0 for auto (read from charset_dir)')
 
     return parser.parse_args()
 
 
-def recognize(image_path: str, weights_path: str, is_vis: bool=True, num_classes: int=0):
+def recognize(image_path: str, charset_dir: str, weights_path: str, is_vis: bool=True, num_classes: int=0):
     """
 
     :param image_path:
-    :param weights_path:
+    :param charset_dir: Path to char_dict.json and ord_map.json (generated with write_text_features.py)
+    :param weights_path: Path to stored weights
     :param is_vis:
     :param num_classes:
     """
@@ -58,7 +62,9 @@ def recognize(image_path: str, weights_path: str, is_vis: bool=True, num_classes
     w, h = config.cfg.ARCH.INPUT_SIZE
     inputdata = tf.placeholder(dtype=tf.float32, shape=[1, h, w, 3], name='input')
 
-    codec = data_utils.TextFeatureIO()
+    codec = data_utils.TextFeatureIO(char_dict_path=ops.join(charset_dir, 'char_dict.json'),
+                                     ord_map_dict_path=ops.join(charset_dir, 'ord_map.json'))
+
     num_classes = len(codec.reader.char_dict) + 1 if num_classes == 0 else num_classes
 
     net = crnn_model.ShadowNet(phase='Test',
@@ -105,5 +111,5 @@ if __name__ == '__main__':
     if not ops.exists(args.image_path):
         raise ValueError('{:s} doesn\'t exist'.format(args.image_path))
 
-    # recognize the image
-    recognize(image_path=args.image_path, weights_path=args.weights_path, num_classes=args.num_classes)
+    recognize(image_path=args.image_path, charset_dir=args.charset_dir,
+              weights_path=args.weights_path, num_classes=args.num_classes)

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -217,8 +217,8 @@ if __name__ == '__main__':
         print("Importing configuration {:s} from {:s}".format(module, path))
         config = importlib.import_module(module)
         sys.path = save_path
-    except:
-        print("Configuration file not found or invalid")
+    except (ModuleNotFoundError, SyntaxError) as e:
+        print("Configuration file not found or invalid: %s" % str(e))
         exit(1)
 
     test_shadownet(dataset_dir=args.dataset_dir, charset_dir=args.charset_dir,

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -30,10 +30,12 @@ def init_args() -> argparse.Namespace:
                         help='Path to test tfrecords data')
     parser.add_argument('-w', '--weights_path', type=str, required=True,
                         help='Path to pre-trained weights')
-    parser.add_argument('-c', '--num_classes', type=int, required=True,
+    parser.add_argument('-c', '--charset_dir', type=str, default='data/char_dict',
+                        help='Path to dir where character sets for the dataset were stored')
+    parser.add_argument('-n', '--num_classes', type=int, required=True,
                         help='Force number of character classes to this number. '
                              'Use 37 to run with the demo data. '
-                             'Set to 0 for auto (read from char_dict)')
+                             'Set to 0 for auto (read from files in charset_dir)')
     parser.add_argument('-f', '--config_file', type=str,
                         help='Use this global configuration file')
     parser.add_argument('-v', '--visualise', type=bool, default=False,
@@ -47,12 +49,13 @@ def init_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def test_shadownet(dataset_dir: str, weights_path: str, cfg: EasyDict, is_vis: bool,
+def test_shadownet(dataset_dir: str, charset_dir: str, weights_path: str, cfg: EasyDict, is_vis: bool,
                    process_all_data: bool=True, num_threads: int=4, num_classes: int=0):
     """
 
-    :param dataset_dir:
-    :param weights_path:
+    :param dataset_dir: Path to Train and Test directories
+    :param charset_dir: Path to char_dict.json and ord_map.json (generated with write_text_features.py)
+    :param weights_path: Path to stored weights
     :param cfg: configuration EasyDict (e.g. global_config.config.cfg)
     :param is_vis: whether to visualise the result
     :param process_all_data:
@@ -60,7 +63,8 @@ def test_shadownet(dataset_dir: str, weights_path: str, cfg: EasyDict, is_vis: b
     :param num_classes: Number of different characters in the dataset
     """
     # Initialize the record decoder
-    decoder = data_utils.TextFeatureIO().reader
+    decoder = data_utils.TextFeatureIO(char_dict_path=ops.join(charset_dir, 'char_dict.json'),
+                                       ord_map_dict_path=ops.join(charset_dir, 'ord_map.json')).reader
     images_t, labels_t, imagenames_t = decoder.read_features(
         ops.join(dataset_dir, 'test_feature.tfrecords'), num_epochs=None)
     if not process_all_data:
@@ -197,6 +201,7 @@ if __name__ == '__main__':
 
     args = init_args()
 
+    config = {}  # Silence PyCharm's checks
     if args.config_file:
         # Remove extension in case the user gave it
         args.config_file = os.path.splitext(args.config_file)[0]
@@ -216,7 +221,6 @@ if __name__ == '__main__':
         print("Configuration file not found or invalid")
         exit(1)
 
-    test_shadownet(dataset_dir=args.dataset_dir, weights_path=args.weights_path,
-                   cfg=config.cfg, process_all_data=not args.one_batch,
-                   is_vis=args.visualise, num_threads=args.num_threads,
-                   num_classes=args.num_classes)
+    test_shadownet(dataset_dir=args.dataset_dir, charset_dir=args.charset_dir,
+                   weights_path=args.weights_path, cfg=config.cfg, process_all_data=not args.one_batch,
+                   is_vis=args.visualise, num_threads=args.num_threads, num_classes=args.num_classes)


### PR DESCRIPTION
This PR is the first of several attempting to solve recent confusion around charsets and number of classes. See e.g. #142 #134 and related.

* Enables charset_dir selection for training, testing and demo (to be used after `write_text_features.py` generates the charset dict and ord dict)
* Does some cosmetic renaming for internal consistency
* pretty-prints json files