### PR TITLE
Blanks in dense output and empty dataset

### DIFF
--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -92,11 +92,7 @@ class FeatureIO(object):
         :param char:
         :return:
         """
-        temp = ord(char)
-        # convert upper character into lower character
-        if 65 <= temp <= 90:
-            temp = temp + 32
-
+        temp = ord(char.lower())
         for k, v in self.__ord_map.items():
             if v == str(temp):
                 temp = int(k)

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -60,6 +60,10 @@ def write_tfrecords(dataset: TextDataset, name: str, save_dir: str, charset_dir:
     labels = dataset.labels
     imagenames = dataset.imagenames
 
+    if dataset.num_examples < 1:
+        print("ERROR: No samples or labels or any found. Is your dataset ok?")
+        return
+
     if charset_dir is not None:
         os.makedirs(os.path.dirname(charset_dir), exist_ok=True)
         # FIXME: rereading every time is a bit silly...


### PR DESCRIPTION
This PR:
* avoids using '*' to decode blanks the sparse to dense decoding of network output since this would collide with character sets including the asterisk
* Warns about datasets without labels, addressing issue #142 