### PR TITLE
Fix: Don't compute seq_distance if decode disabled

### DIFF
--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -114,7 +114,8 @@ def train_shadownet(cfg: EasyDict, weights_path: str=None, decode: bool=False, n
     os.makedirs(cfg.PATH.TBOARD_SAVE_DIR, exist_ok=True)
     tf.summary.scalar(name='Cost', tensor=cost)
     tf.summary.scalar(name='Learning_Rate', tensor=learning_rate)
-    tf.summary.scalar(name='Seq_Dist', tensor=sequence_dist)
+    if decode:
+        tf.summary.scalar(name='Seq_Dist', tensor=sequence_dist)
     merge_summary_op = tf.summary.merge_all()
 
     # Set saver configuration


### PR DESCRIPTION
This PR fixes the disabling of prediction decoding during training, which was still being done despite the command line flag (thanks to @xuenhappy in #71)