### PR TITLE
Don't convert queried chars to lower case

### DIFF
--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -92,7 +92,7 @@ class FeatureIO(object):
         :param char:
         :return:
         """
-        temp = ord(char.lower())
+        temp = ord(char)
         for k, v in self.__ord_map.items():
             if v == str(temp):
                 temp = int(k)


### PR DESCRIPTION
This MR undoes the automatic conversion to lower case of queried chars in `char_to_int()`. Forcing the conversion only during querying of the charmap cannot work unless all labels are lowercased first, and this is not necessarily something desirable.

This seems like a potentially problematic change, but I suppose that people haven't had issues with this because many use charsets without upper and lower cases.