### PR TITLE
Early stopping

### DIFF
--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -53,6 +53,8 @@ __C.TRAIN.VAL_BATCH_SIZE = 32
 __C.TRAIN.LR_DECAY_STEPS = 10000
 # Set the learning rate decay rate
 __C.TRAIN.LR_DECAY_RATE = 0.1
+# Update learning rate in jumps?
+__C.TRAIN.LR_STAIRCASE = False
 
 # Test options
 __C.TEST = edict()

--- a/global_configuration/config.py
+++ b/global_configuration/config.py
@@ -31,6 +31,13 @@ __C.ARCH.INPUT_CHANNELS = 3
 # Train options
 __C.TRAIN = edict()
 
+# Use early stopping?
+__C.TRAIN.EARLY_STOPPING = True
+# Wait at least this many epochs without improvement in the cost function
+__C.TRAIN.PATIENCE_EPOCHS = 6
+# Expect at least this improvement in one epoch in order to reset the early stopping counter
+__C.TRAIN.PATIENCE_DELTA = 1e-3
+
 # Set the shadownet training epochs
 __C.TRAIN.EPOCHS = 40000
 # Set the display step

--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -104,7 +104,7 @@ def train_shadownet(cfg: EasyDict, weights_path: str=None, decode: bool=False, n
     starter_learning_rate = cfg.TRAIN.LEARNING_RATE
     learning_rate = tf.train.exponential_decay(starter_learning_rate, global_step,
                                                cfg.TRAIN.LR_DECAY_STEPS, cfg.TRAIN.LR_DECAY_RATE,
-                                               staircase=True)
+                                               staircase=cfg.TRAIN.LR_STAIRCASE)
     update_ops = tf.get_collection(tf.GraphKeys.UPDATE_OPS)
 
     with tf.control_dependencies(update_ops):

--- a/tools/train_shadownet.py
+++ b/tools/train_shadownet.py
@@ -154,9 +154,9 @@ def train_shadownet(cfg: EasyDict, weights_path: str=None, decode: bool=False, n
         patience_counter = 1
         cost_history = [np.inf]
         for epoch in range(train_epochs):
-            if cfg.TRAIN.EARLY_STOPPING:
+            if epoch > 1 and cfg.TRAIN.EARLY_STOPPING:
                 # We always compare to the first point where cost didn't improve
-                if cost_history[epoch - patience_counter] - cost_history[epoch] > cfg.TRAIN.PATIENCE_DELTA:
+                if cost_history[-1 - patience_counter] - cost_history[-1] > cfg.TRAIN.PATIENCE_DELTA:
                     patience_counter = 1
                 else:
                     patience_counter += 1

--- a/tools/write_text_features.py
+++ b/tools/write_text_features.py
@@ -100,13 +100,12 @@ if __name__ == '__main__':
 
     os.makedirs(args.save_dir, exist_ok=True)
 
-    print('Initializing the dataset provider... ', end='', flush=True)
+    print('Initializing the dataset provider...')
 
     provider = data_provider.TextDataProvider(dataset_dir=args.dataset_dir, annotation_name=args.annotation_file,
                                               validation_set=args.validation_split > 0,
                                               validation_split=args.validation_split, shuffle='every_epoch',
                                               normalization=args.normalization, input_size=config.cfg.ARCH.INPUT_SIZE)
-    print('done.')
 
     write_tfrecords(provider.train, "train", args.save_dir, args.charset_dir)
     write_tfrecords(provider.test, "test", args.save_dir, args.charset_dir)


### PR DESCRIPTION
This PR implements early stopping, configurable in `config.py` via a new set of parameters. For all epochs `t`, training will stop at epoch `t + cfg.TRAIN.PATIENCE_EPOCHS` if the cost at any epoch `t+i` for all `0 < i <= cfg.TRAIN.PATIENCE_EPOCHS` hasn't improved by more than `cfg.TRAIN.PATIENCE_DELTA` since epoch `t`.
(merge after #160 since it is based upon that branch)