### PR TITLE
Update data_utils.py

### DIFF
--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -213,7 +213,7 @@ class TextFeatureReader(FeatureIO):
         :return: input_images, input_labels, input_image_names
         """
 
-        tfrecords_path = os.path.join(cfg.PATH.TFRECORDS_DIR, "train_feature.tfrecords")
+        tfrecords_path = os.path.join(cfg.PATH.TFRECORDS_DIR, "test_feature.tfrecords")
         assert ops.exists(tfrecords_path), "tfrecords file not found: %s" % tfrecords_path
 
         def extract_batch(x):


### PR DESCRIPTION
correct tfrecords file name to test_feature.tfrecords so that there wont be error in running test_shadownet.py 

-test_shadownet.py is move out from the tools directory to the CRNN_Tensorflow-master root path to prevent module not found error.