### PR TITLE
Fix loading train data at test time

### DIFF
--- a/local_utils/data_utils.py
+++ b/local_utils/data_utils.py
@@ -204,7 +204,7 @@ class TextFeatureReader(FeatureIO):
         return
 
     @staticmethod
-    def read_features(cfg: EasyDict, batch_size: int, num_threads: int) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
+    def read_features(cfg: EasyDict, batch_size: int, num_threads: int, isTrain: bool=True) -> Tuple[tf.Tensor, tf.Tensor, tf.Tensor]:
         """
 
         :param cfg:
@@ -212,10 +212,13 @@ class TextFeatureReader(FeatureIO):
         :param num_threads:
         :return: input_images, input_labels, input_image_names
         """
-
-        tfrecords_path = os.path.join(cfg.PATH.TFRECORDS_DIR, "train_feature.tfrecords")
-        assert ops.exists(tfrecords_path), "tfrecords file not found: %s" % tfrecords_path
-
+        if isTrain:
+            tfrecords_path = os.path.join(cfg.PATH.TFRECORDS_DIR, "train_feature.tfrecords")
+            assert ops.exists(tfrecords_path), "tfrecords file not found: %s" % tfrecords_path
+        else:
+            tfrecords_path = os.path.join(cfg.PATH.TFRECORDS_DIR, "test_feature.tfrecords")
+            assert ops.exists(tfrecords_path), "tfrecords file not found: %s" % tfrecords_path            
+        
         def extract_batch(x):
             return TextFeatureReader.extract_features_batch(x, cfg.ARCH.INPUT_SIZE, cfg.ARCH.INPUT_CHANNELS)
 

--- a/tools/test_shadownet.py
+++ b/tools/test_shadownet.py
@@ -77,7 +77,7 @@ def test_shadownet(weights_path: str, cfg: EasyDict, visualize: bool, process_al
     """
     decoder = data_utils.TextFeatureIO(char_dict_path=ops.join(cfg.PATH.CHAR_DICT_DIR, 'char_dict.json'),
                                        ord_map_dict_path=ops.join(cfg.PATH.CHAR_DICT_DIR, 'ord_map.json')).reader
-    input_images, input_labels, input_image_names = decoder.read_features(cfg, cfg.TEST.BATCH_SIZE, num_threads)
+    input_images, input_labels, input_image_names = decoder.read_features(cfg, cfg.TEST.BATCH_SIZE, num_threads, False)
 
     num_classes = len(decoder.char_dict) + 1 if num_classes == 0 else num_classes
     net = crnn_model.ShadowNet(phase='Test', hidden_nums=cfg.ARCH.HIDDEN_UNITS,


### PR DESCRIPTION
When testing, model is loading ```train_features.tfrecords```, but it should be ```test_features.tfrecords```. This request fixed it. 

```local_utils/data_utils.py``` will now default train to be ```True``` and search for train tfrecords. When testing, isTrain is changed to False, and model will search for test tfrecords instead. There is no need to modify train script.